### PR TITLE
refactor(hooks): share hook utilities and add tests

### DIFF
--- a/src/packages/meeting-room-hooks/README.md
+++ b/src/packages/meeting-room-hooks/README.md
@@ -7,6 +7,15 @@
 - `ws-relay.py`: PostToolUse hook to relay `SendMessage` payloads over WebSocket.
 - `subagent-status-relay.py`: PostToolUse hook to relay `SubagentStop` status events.
 - `stop-relay.py`: Stop hook to relay the latest assistant response over WebSocket.
+- `hook_common.py`: meeting mode 判定、env/path 解決、stdin JSON 解析などの共通基盤。
+- `hook_transport.py`: WebSocket relay と JSONL fallback log の共通 transport。
+- `hook_text.py`: relay 用テキストフィルタの共通ロジック。
+
+## Local Tests
+
+```bash
+python3 -m unittest discover -s src/packages/meeting-room-hooks/tests
+```
 
 ## Quick Local Checks
 

--- a/src/packages/meeting-room-hooks/approval-gate.py
+++ b/src/packages/meeting-room-hooks/approval-gate.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -12,59 +11,10 @@ from typing import Any
 
 from contracts import (
     ApprovalGateFields as AG,
-    HookEnvVars as E,
 )
+from hook_common import is_meeting_mode_active, resolve_approval_file
 
 BLOCK_MESSAGE = "[Meeting Room] 承認待ちです。ユーザーが確認してから次へ進めてください。"
-APPROVAL_DIR_RELATIVE = Path(".claude") / "meeting-room" / "approval"
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    return any(path.exists() for path in _candidate_active_paths())
-
-
-def resolve_repo_root() -> Path:
-    settings_path = os.environ.get(E.SETTINGS_FILE, "").strip()
-    if settings_path:
-        return Path(settings_path).expanduser().resolve().parent.parent
-
-    hooks_dir = os.environ.get(E.HOOKS_DIR, "").strip()
-    if hooks_dir:
-        return Path(hooks_dir).expanduser().resolve().parent
-
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
-    if project_dir:
-        return Path(project_dir).expanduser().resolve()
-
-    return Path.cwd()
-
-
-def resolve_approval_file() -> Path | None:
-    direct = os.environ.get(E.APPROVAL_FILE, "").strip()
-    if direct:
-        return Path(direct).expanduser()
-
-    meeting_id = os.environ.get(E.MEETING_ID, "").strip()
-    if not meeting_id:
-        return None
-
-    approval_dir = os.environ.get(E.APPROVAL_DIR, "").strip()
-    if approval_dir:
-        return Path(approval_dir).expanduser() / f"{meeting_id}.json"
-
-    return resolve_repo_root() / APPROVAL_DIR_RELATIVE / f"{meeting_id}.json"
 
 
 def parse_approval_state(path: Path) -> dict[str, Any] | None:

--- a/src/packages/meeting-room-hooks/enforce-broadcast.py
+++ b/src/packages/meeting-room-hooks/enforce-broadcast.py
@@ -8,49 +8,16 @@ while meeting mode is active. Subagent-to-subagent directed messages are allowed
 from __future__ import annotations
 
 import json
-import os
 import sys
-from pathlib import Path
 from typing import Any
 
 
 from contracts import HookEnvVars as E
+from hook_common import is_meeting_mode_active, is_subagent_context, parse_json_stdin
 
 BLOCK_MESSAGE = """[Meeting Room] directed メッセージは禁止です。
 type: "broadcast" を使って全員に共有してください。
 会議室モードでは全メッセージが全員に見えます。"""
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    for path in _candidate_active_paths():
-        if path.exists():
-            return True
-    return False
-
-
-def parse_payload() -> dict[str, Any]:
-    raw = sys.stdin.read().strip()
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if isinstance(data, dict):
-        return data
-    return {}
 
 
 def extract_send_message_type(payload: dict[str, Any]) -> str | None:
@@ -66,16 +33,11 @@ def extract_send_message_type(payload: dict[str, Any]) -> str | None:
     return None
 
 
-def is_subagent_context() -> bool:
-    subagent = os.environ.get("CLAUDE_SUBAGENT_NAME", "").strip()
-    return bool(subagent)
-
-
 def main() -> int:
     if not is_meeting_mode_active():
         return 0
 
-    payload = parse_payload()
+    payload = parse_json_stdin()
     msg_type = extract_send_message_type(payload)
 
     if msg_type == "message" and not is_subagent_context():

--- a/src/packages/meeting-room-hooks/hook_common.py
+++ b/src/packages/meeting-room-hooks/hook_common.py
@@ -1,0 +1,116 @@
+"""Shared runtime helpers for Meeting Room hook scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Mapping, TextIO
+
+from contracts import HookEnvVars as E
+
+MEETING_ROOM_DIR = Path(".claude") / "meeting-room"
+DEFAULT_APPROVAL_DIR = MEETING_ROOM_DIR / "approval"
+
+
+def as_str(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def get_env_str(name: str, *, env: Mapping[str, str] | None = None) -> str:
+    values = env if env is not None else os.environ
+    return as_str(values.get(name))
+
+
+def default_meeting_room_path(*parts: str, cwd: Path | None = None) -> Path:
+    base_dir = cwd if cwd is not None else Path.cwd()
+    return base_dir / MEETING_ROOM_DIR / Path(*parts)
+
+
+def candidate_active_paths(
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    home: Path | None = None,
+) -> list[Path]:
+    values = env if env is not None else os.environ
+    paths: list[Path] = []
+
+    env_path = as_str(values.get(E.ACTIVE_FILE))
+    if env_path:
+        paths.append(Path(env_path).expanduser())
+
+    current_dir = cwd if cwd is not None else Path.cwd()
+    home_dir = home if home is not None else Path.home()
+    paths.append(current_dir / MEETING_ROOM_DIR / ".active")
+    paths.append(home_dir / MEETING_ROOM_DIR / ".active")
+    return paths
+
+
+def is_meeting_mode_active(
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    home: Path | None = None,
+) -> bool:
+    return any(path.exists() for path in candidate_active_paths(env=env, cwd=cwd, home=home))
+
+
+def is_subagent_context(*, env: Mapping[str, str] | None = None) -> bool:
+    return bool(get_env_str("CLAUDE_SUBAGENT_NAME", env=env))
+
+
+def parse_json_stdin(stdin: TextIO | None = None) -> dict[str, Any]:
+    stream = stdin if stdin is not None else sys.stdin
+    raw = stream.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def extract_mapping(payload: Mapping[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def resolve_repo_root(*, env: Mapping[str, str] | None = None, cwd: Path | None = None) -> Path:
+    settings_path = get_env_str(E.SETTINGS_FILE, env=env)
+    if settings_path:
+        return Path(settings_path).expanduser().resolve().parent.parent
+
+    hooks_dir = get_env_str(E.HOOKS_DIR, env=env)
+    if hooks_dir:
+        return Path(hooks_dir).expanduser().resolve().parent
+
+    project_dir = get_env_str("CLAUDE_PROJECT_DIR", env=env)
+    if project_dir:
+        return Path(project_dir).expanduser().resolve()
+
+    return cwd if cwd is not None else Path.cwd()
+
+
+def resolve_approval_file(
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    repo_root: Path | None = None,
+) -> Path | None:
+    direct = get_env_str(E.APPROVAL_FILE, env=env)
+    if direct:
+        return Path(direct).expanduser()
+
+    meeting_id = get_env_str(E.MEETING_ID, env=env)
+    if not meeting_id:
+        return None
+
+    approval_dir = get_env_str(E.APPROVAL_DIR, env=env)
+    if approval_dir:
+        return Path(approval_dir).expanduser() / f"{meeting_id}.json"
+
+    base_dir = repo_root if repo_root is not None else resolve_repo_root(env=env, cwd=cwd)
+    return base_dir / DEFAULT_APPROVAL_DIR / f"{meeting_id}.json"

--- a/src/packages/meeting-room-hooks/hook_text.py
+++ b/src/packages/meeting-room-hooks/hook_text.py
@@ -1,0 +1,42 @@
+"""Shared text filters for Meeting Room hook scripts."""
+
+from __future__ import annotations
+
+import re
+
+from contracts import ResponseMarkers as M
+
+PATH_ONLY_PATTERN = re.compile(r"^(?:/Users/|/home/|[A-Za-z]:\\).+\.(?:jsonl|json|md|txt|log)$")
+
+
+def is_path_only_reference(value: str) -> bool:
+    return bool(PATH_ONLY_PATTERN.match(value.strip()))
+
+
+def is_single_line_prompt(value: str) -> bool:
+    compact = value.strip()
+    return compact.startswith("@") and "❯" in compact and "\n" not in compact
+
+
+def is_valid_message_content(value: str) -> bool:
+    compact = value.strip()
+    if not compact:
+        return False
+    if compact.startswith(M.START):
+        return False
+    if is_single_line_prompt(compact):
+        return False
+    if is_path_only_reference(compact):
+        return False
+    return True
+
+
+def is_valid_assistant_text(value: str) -> bool:
+    compact = value.strip()
+    if not compact:
+        return False
+    if is_single_line_prompt(compact):
+        return False
+    if is_path_only_reference(compact):
+        return False
+    return True

--- a/src/packages/meeting-room-hooks/hook_transport.py
+++ b/src/packages/meeting-room-hooks/hook_transport.py
@@ -1,0 +1,140 @@
+"""Shared relay transport helpers for Meeting Room hook scripts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from contracts import HookEnvVars as E
+from hook_common import as_str
+
+GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+@dataclass(frozen=True)
+class WebSocketConfig:
+    host: str
+    port: int
+    path: str
+    timeout: float
+
+
+def _load_ws_config(*, env: Mapping[str, str] | None = None) -> WebSocketConfig:
+    values = env if env is not None else os.environ
+    host = as_str(values.get(E.WS_HOST)) or "127.0.0.1"
+    ws_path = as_str(values.get(E.WS_PATH)) or "/"
+
+    port_raw = as_str(values.get(E.WS_PORT)) or "9999"
+    try:
+        port = int(port_raw)
+    except ValueError:
+        port = 9999
+
+    timeout_raw = as_str(values.get(E.WS_TIMEOUT)) or "0.8"
+    try:
+        timeout = float(timeout_raw)
+    except ValueError:
+        timeout = 0.8
+
+    return WebSocketConfig(host=host, port=port, path=ws_path, timeout=timeout)
+
+
+def _recv_until(sock: socket.socket, marker: bytes) -> bytes:
+    data = b""
+    while marker not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+        if len(data) > 65536:
+            break
+    return data
+
+
+def _build_ws_frame(payload: bytes) -> bytes:
+    first = bytes([0x81])
+    mask_bit = 0x80
+    size = len(payload)
+
+    if size < 126:
+        header = first + bytes([mask_bit | size])
+    elif size < (1 << 16):
+        header = first + bytes([mask_bit | 126]) + size.to_bytes(2, "big")
+    else:
+        header = first + bytes([mask_bit | 127]) + size.to_bytes(8, "big")
+
+    mask = secrets.token_bytes(4)
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return header + mask + masked
+
+
+def send_ws_json(message: Mapping[str, Any], *, env: Mapping[str, str] | None = None) -> None:
+    config = _load_ws_config(env=env)
+    body = json.dumps(message, ensure_ascii=False).encode("utf-8")
+    key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
+    expected_accept = base64.b64encode(hashlib.sha1(f"{key}{GUID}".encode("ascii")).digest()).decode("ascii")
+
+    request = (
+        f"GET {config.path} HTTP/1.1\r\n"
+        f"Host: {config.host}:{config.port}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    ).encode("ascii")
+
+    with socket.create_connection((config.host, config.port), timeout=config.timeout) as sock:
+        sock.settimeout(config.timeout)
+        sock.sendall(request)
+        response = _recv_until(sock, b"\r\n\r\n").decode("latin1", errors="ignore")
+        if "101" not in response.split("\r\n", 1)[0]:
+            raise RuntimeError("websocket handshake failed")
+        if expected_accept not in response:
+            raise RuntimeError("invalid websocket accept key")
+        sock.sendall(_build_ws_frame(body))
+
+
+def append_jsonl(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def resolve_log_path(
+    default_path: Path,
+    *,
+    env_var: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    if env_var:
+        values = env if env is not None else os.environ
+        custom_path = as_str(values.get(env_var))
+        if custom_path:
+            return Path(custom_path).expanduser()
+    return default_path
+
+
+def relay_json_with_fallback(
+    message: Mapping[str, Any],
+    *,
+    default_log_path: Path,
+    fallback_env_var: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    try:
+        send_ws_json(message, env=env)
+    except Exception:
+        try:
+            append_jsonl(
+                resolve_log_path(default_log_path, env_var=fallback_env_var, env=env),
+                message,
+            )
+        except Exception:
+            pass

--- a/src/packages/meeting-room-hooks/stop-relay.py
+++ b/src/packages/meeting-room-hooks/stop-relay.py
@@ -3,14 +3,7 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
-import os
-import re
-import secrets
-import socket
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -22,63 +15,31 @@ from contracts import (
     RelayPayloadTypes as T,
     ResponseMarkers as M,
 )
-
-GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-WS_HOST = os.environ.get(E.WS_HOST, "127.0.0.1")
-WS_PORT = int(os.environ.get(E.WS_PORT, "9999"))
-WS_PATH = os.environ.get(E.WS_PATH, "/")
-WS_TIMEOUT = float(os.environ.get(E.WS_TIMEOUT, "0.8"))
+from hook_common import (
+    as_str,
+    default_meeting_room_path,
+    get_env_str,
+    is_meeting_mode_active,
+    is_subagent_context,
+    parse_json_stdin,
+)
+from hook_text import is_valid_assistant_text
+from hook_transport import relay_json_with_fallback
 
 DEFAULT_DEBUG_LOG = Path.cwd() / ".claude" / "meeting-room" / "stop-hook.log.jsonl"
-PATH_ONLY_PATTERN = re.compile(r"^(?:/Users/|/home/|[A-Za-z]:\\).+\.(?:jsonl|json|md|txt|log)$")
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    for path in _candidate_active_paths():
-        if path.exists():
-            return True
-    return False
-
-
-def is_subagent_context() -> bool:
-    return bool(os.environ.get("CLAUDE_SUBAGENT_NAME", "").strip())
-
-
-def parse_payload() -> dict[str, Any]:
-    raw = sys.stdin.read().strip()
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if isinstance(data, dict):
-        return data
-    return {}
 
 
 def _extract_str_any(payload: dict[str, Any], *keys: str) -> str:
     for key in keys:
         value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+        compact = as_str(value)
+        if compact:
+            return compact
     return ""
 
 
 def _extract_str(payload: dict[str, Any], key: str) -> str:
-    value = payload.get(key)
-    return value.strip() if isinstance(value, str) else ""
+    return as_str(payload.get(key))
 
 
 def _extract_text_blocks(value: Any) -> list[str]:
@@ -123,7 +84,7 @@ def _extract_assistant_text_from_record(record: Any) -> str:
 def _extract_assistant_from_transcript(payload: dict[str, Any]) -> str:
     transcript_path = _extract_str_any(payload, "transcript_path")
     if not transcript_path:
-        transcript_path = os.environ.get("CLAUDE_TRANSCRIPT_PATH", "").strip()
+        transcript_path = get_env_str("CLAUDE_TRANSCRIPT_PATH")
     if not transcript_path:
         return ""
 
@@ -216,21 +177,14 @@ def _pick_best_text(candidates: list[str]) -> str:
 
 
 def _is_valid_assistant_text(value: str) -> bool:
-    compact = value.strip()
-    if not compact:
-        return False
-    if PATH_ONLY_PATTERN.match(compact):
-        return False
-    if compact.startswith("@") and "❯" in compact and "\n" not in compact:
-        return False
-    return True
+    return is_valid_assistant_text(value)
 
 
 def extract_assistant_response(payload: dict[str, Any]) -> str:
     env_candidates = [
-        os.environ.get("CLAUDE_RESPONSE", "").strip(),
-        os.environ.get("CLAUDE_LAST_ASSISTANT_MESSAGE", "").strip(),
-        os.environ.get("CLAUDE_ASSISTANT_MESSAGE", "").strip(),
+        get_env_str("CLAUDE_RESPONSE"),
+        get_env_str("CLAUDE_LAST_ASSISTANT_MESSAGE"),
+        get_env_str("CLAUDE_ASSISTANT_MESSAGE"),
     ]
     for item in env_candidates:
         if _is_valid_assistant_text(item):
@@ -271,12 +225,12 @@ def extract_assistant_response(payload: dict[str, Any]) -> str:
 
 
 def write_debug(payload: dict[str, Any], content: str) -> None:
-    path = os.environ.get(E.STOP_DEBUG_LOG, "").strip()
+    path = get_env_str(E.STOP_DEBUG_LOG)
     debug_path = Path(path).expanduser() if path else DEFAULT_DEBUG_LOG
     debug_path.parent.mkdir(parents=True, exist_ok=True)
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "stopReason": os.environ.get("CLAUDE_STOP_REASON", ""),
+        "stopReason": get_env_str("CLAUDE_STOP_REASON"),
         "payloadKeys": sorted(payload.keys()),
         "hasContent": bool(content.strip()),
         "contentPreview": content[:200],
@@ -285,76 +239,10 @@ def write_debug(payload: dict[str, Any], content: str) -> None:
         fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
-def _recv_until(sock: socket.socket, marker: bytes) -> bytes:
-    data = b""
-    while marker not in data:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        data += chunk
-        if len(data) > 65536:
-            break
-    return data
-
-
-def _build_ws_frame(payload: bytes) -> bytes:
-    first = bytes([0x81])  # FIN + text frame
-    mask_bit = 0x80
-    size = len(payload)
-
-    if size < 126:
-        header = first + bytes([mask_bit | size])
-    elif size < (1 << 16):
-        header = first + bytes([mask_bit | 126]) + size.to_bytes(2, "big")
-    else:
-        header = first + bytes([mask_bit | 127]) + size.to_bytes(8, "big")
-
-    mask = secrets.token_bytes(4)
-    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return header + mask + masked
-
-
-def send_ws_json(message: dict[str, Any]) -> None:
-    body = json.dumps(message, ensure_ascii=False).encode("utf-8")
-    key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
-    expected_accept = base64.b64encode(hashlib.sha1(f"{key}{GUID}".encode("ascii")).digest()).decode("ascii")
-
-    request = (
-        f"GET {WS_PATH} HTTP/1.1\r\n"
-        f"Host: {WS_HOST}:{WS_PORT}\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        f"Sec-WebSocket-Key: {key}\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n"
-    ).encode("ascii")
-
-    with socket.create_connection((WS_HOST, WS_PORT), timeout=WS_TIMEOUT) as sock:
-        sock.settimeout(WS_TIMEOUT)
-        sock.sendall(request)
-        response = _recv_until(sock, b"\r\n\r\n").decode("latin1", errors="ignore")
-        if "101" not in response.split("\r\n", 1)[0]:
-            raise RuntimeError("websocket handshake failed")
-        if expected_accept not in response:
-            raise RuntimeError("invalid websocket accept key")
-        sock.sendall(_build_ws_frame(body))
-
-
-def fallback_log(message: dict[str, Any]) -> None:
-    path_env = os.environ.get(E.FALLBACK_LOG)
-    if path_env:
-        log_path = Path(path_env).expanduser()
-    else:
-        log_path = Path.cwd() / ".claude" / "meeting-room" / "discussion.log.jsonl"
-
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(message, ensure_ascii=False) + "\n")
-
-
 def build_message(content: str) -> dict[str, Any]:
-    sender = os.environ.get("CLAUDE_AGENT_NAME", "").strip() or "leader"
-    team = os.environ.get("CLAUDE_TEAM_NAME", "").strip() or "leader"
-    meeting_id = os.environ.get(E.MEETING_ID, "").strip() or None
+    sender = get_env_str("CLAUDE_AGENT_NAME") or "leader"
+    team = get_env_str("CLAUDE_TEAM_NAME") or "leader"
+    meeting_id = get_env_str(E.MEETING_ID) or None
     timestamp = datetime.now(timezone.utc).isoformat()
     msg_id = f"stop_{int(datetime.now(tz=timezone.utc).timestamp())}_{sender.replace(' ', '_')}"
 
@@ -378,7 +266,7 @@ def main() -> int:
     if is_subagent_context():
         return 0
 
-    payload = parse_payload()
+    payload = parse_json_stdin()
     if _extract_str_any(payload, "hook_event_name").lower() != "stop":
         return 0
     content = extract_assistant_response(payload)
@@ -390,13 +278,11 @@ def main() -> int:
         return 0
 
     message = build_message(content)
-    try:
-        send_ws_json(message)
-    except Exception:
-        try:
-            fallback_log(message)
-        except Exception:
-            pass
+    relay_json_with_fallback(
+        message,
+        default_log_path=default_meeting_room_path("discussion.log.jsonl"),
+        fallback_env_var=E.FALLBACK_LOG,
+    )
     return 0
 
 

--- a/src/packages/meeting-room-hooks/subagent-status-relay.py
+++ b/src/packages/meeting-room-hooks/subagent-status-relay.py
@@ -3,15 +3,7 @@
 
 from __future__ import annotations
 
-import json
-import os
-import base64
-import hashlib
-import secrets
-import socket
-import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 
 from contracts import (
@@ -20,131 +12,34 @@ from contracts import (
     RelayPayloadFields as F,
     RelayPayloadTypes as T,
 )
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    for path in _candidate_active_paths():
-        if path.exists():
-            return True
-    return False
-
-
-def parse_payload() -> dict:
-    raw = sys.stdin.read().strip()
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def _recv_until(sock: socket.socket, marker: bytes) -> bytes:
-    data = b""
-    while marker not in data:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        data += chunk
-        if len(data) > 65536:
-            break
-    return data
-
-
-def _build_ws_frame(payload: bytes) -> bytes:
-    first = bytes([0x81])
-    mask_bit = 0x80
-    size = len(payload)
-    if size < 126:
-        header = first + bytes([mask_bit | size])
-    elif size < (1 << 16):
-        header = first + bytes([mask_bit | 126]) + size.to_bytes(2, "big")
-    else:
-        header = first + bytes([mask_bit | 127]) + size.to_bytes(8, "big")
-    mask = secrets.token_bytes(4)
-    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return header + mask + masked
-
-
-def send_json(payload: dict) -> None:
-    host = os.environ.get(E.WS_HOST, "127.0.0.1")
-    port = int(os.environ.get(E.WS_PORT, "9999"))
-    ws_path = os.environ.get(E.WS_PATH, "/")
-    timeout = float(os.environ.get(E.WS_TIMEOUT, "0.8"))
-    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-
-    guid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-    key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
-    expected_accept = base64.b64encode(hashlib.sha1(f"{key}{guid}".encode("ascii")).digest()).decode("ascii")
-    request = (
-        f"GET {ws_path} HTTP/1.1\r\n"
-        f"Host: {host}:{port}\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        f"Sec-WebSocket-Key: {key}\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n"
-    ).encode("ascii")
-
-    with socket.create_connection((host, port), timeout=timeout) as sock:
-        sock.settimeout(timeout)
-        sock.sendall(request)
-        response = _recv_until(sock, b"\r\n\r\n").decode("latin1", errors="ignore")
-        if "101" not in response.split("\r\n", 1)[0] or expected_accept not in response:
-            raise RuntimeError("websocket handshake failed")
-        sock.sendall(_build_ws_frame(body))
-
-
-def fallback_log(payload: dict) -> None:
-    log_path = os.environ.get(E.STATUS_LOG)
-    if not log_path:
-        log_path = os.path.join(os.getcwd(), ".claude", "meeting-room", "status.log.jsonl")
-    os.makedirs(os.path.dirname(log_path), exist_ok=True)
-    with open(log_path, "a", encoding="utf-8") as fh:
-        fh.write(json.dumps(payload, ensure_ascii=False) + "\n")
+from hook_common import default_meeting_room_path, get_env_str, is_meeting_mode_active, parse_json_stdin
+from hook_transport import relay_json_with_fallback
 
 
 def main() -> int:
     if not is_meeting_mode_active():
         return 0
 
-    payload = parse_payload()
+    payload = parse_json_stdin()
     if not payload:
         return 0
-    sender = os.environ.get("CLAUDE_SUBAGENT_NAME") or os.environ.get("CLAUDE_AGENT_NAME") or "agent"
-    meeting_id = os.environ.get(E.MEETING_ID)
-    if not isinstance(meeting_id, str) or not meeting_id.strip():
-        meeting_id = None
-    else:
-        meeting_id = meeting_id.strip()
+    sender = get_env_str("CLAUDE_SUBAGENT_NAME") or get_env_str("CLAUDE_AGENT_NAME") or "agent"
+    meeting_id = get_env_str(E.MEETING_ID) or None
     event = {
         F.TYPE: T.AGENT_STATUS,
         F.ID: f"status_{int(datetime.now(tz=timezone.utc).timestamp())}_{sender}",
         F.SENDER: sender,
         F.CONTENT: S.COMPLETED,
         F.TIMESTAMP: datetime.now(timezone.utc).isoformat(),
-        F.TEAM: os.environ.get("CLAUDE_TEAM_NAME", "unknown"),
+        F.TEAM: get_env_str("CLAUDE_TEAM_NAME") or "unknown",
         F.MEETING_ID: meeting_id,
         F.STATUS: S.COMPLETED,
     }
-    try:
-        send_json(event)
-    except Exception:
-        try:
-            fallback_log(event)
-        except Exception:
-            pass
+    relay_json_with_fallback(
+        event,
+        default_log_path=default_meeting_room_path("status.log.jsonl"),
+        fallback_env_var=E.STATUS_LOG,
+    )
     return 0
 
 

--- a/src/packages/meeting-room-hooks/team-event-relay.py
+++ b/src/packages/meeting-room-hooks/team-event-relay.py
@@ -3,15 +3,8 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
-import os
 import secrets
-import socket
-import sys
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 
@@ -20,56 +13,18 @@ from contracts import (
     RelayPayloadFields as F,
     RelayPayloadTypes as T,
 )
-
-GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-WS_HOST = os.environ.get(E.WS_HOST, "127.0.0.1")
-WS_PORT = int(os.environ.get(E.WS_PORT, "9999"))
-WS_PATH = os.environ.get(E.WS_PATH, "/")
-WS_TIMEOUT = float(os.environ.get(E.WS_TIMEOUT, "0.8"))
+from hook_common import (
+    as_str,
+    default_meeting_room_path,
+    extract_mapping,
+    get_env_str,
+    is_meeting_mode_active,
+    is_subagent_context,
+    parse_json_stdin,
+)
+from hook_transport import relay_json_with_fallback
 
 EVENT_TOOL_NAMES = {"teamcreate", "create_team", "create-team", "task"}
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    for path in _candidate_active_paths():
-        if path.exists():
-            return True
-    return False
-
-
-def is_subagent_context() -> bool:
-    return bool(os.environ.get("CLAUDE_SUBAGENT_NAME", "").strip())
-
-
-def parse_payload() -> dict[str, Any]:
-    raw = sys.stdin.read().strip()
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if isinstance(data, dict):
-        return data
-    return {}
-
-
-def _extract_dict(payload: dict[str, Any], key: str) -> dict[str, Any]:
-    value = payload.get(key)
-    if isinstance(value, dict):
-        return value
-    return {}
 
 
 def _extract_tool_name(payload: dict[str, Any]) -> str:
@@ -77,7 +32,7 @@ def _extract_tool_name(payload: dict[str, Any]) -> str:
         candidate = payload.get(key)
         if isinstance(candidate, str) and candidate.strip():
             return candidate.strip()
-    metadata = _extract_dict(payload, "metadata")
+    metadata = extract_mapping(payload, "metadata")
     for key in ("tool_name", "tool"):
         candidate = metadata.get(key)
         if isinstance(candidate, str) and candidate.strip():
@@ -86,7 +41,7 @@ def _extract_tool_name(payload: dict[str, Any]) -> str:
 
 
 def _extract_task_text(payload: dict[str, Any]) -> str:
-    tool_input = _extract_dict(payload, "tool_input")
+    tool_input = extract_mapping(payload, "tool_input")
     for key in ("description", "prompt", "task", "content", "message"):
         value = tool_input.get(key)
         if isinstance(value, str) and value.strip():
@@ -95,7 +50,7 @@ def _extract_task_text(payload: dict[str, Any]) -> str:
 
 
 def _extract_member_count(payload: dict[str, Any]) -> int | None:
-    tool_input = _extract_dict(payload, "tool_input")
+    tool_input = extract_mapping(payload, "tool_input")
     for key in ("members", "member_ids", "agents"):
         value = tool_input.get(key)
         if isinstance(value, list):
@@ -115,8 +70,8 @@ def should_emit(payload: dict[str, Any]) -> tuple[bool, str]:
 
 def build_event_message(payload: dict[str, Any], normalized_tool_name: str) -> dict[str, Any]:
     sender = "system"
-    team = os.environ.get("CLAUDE_TEAM_NAME", "").strip() or "meeting-room"
-    meeting_id = os.environ.get(E.MEETING_ID, "").strip() or None
+    team = get_env_str("CLAUDE_TEAM_NAME") or "meeting-room"
+    meeting_id = get_env_str(E.MEETING_ID) or None
     timestamp = datetime.now(timezone.utc).isoformat()
     msg_id = f"team_event_{int(datetime.now(tz=timezone.utc).timestamp())}_{secrets.token_hex(3)}"
 
@@ -146,82 +101,16 @@ def build_event_message(payload: dict[str, Any], normalized_tool_name: str) -> d
     }
 
 
-def _recv_until(sock: socket.socket, marker: bytes) -> bytes:
-    data = b""
-    while marker not in data:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        data += chunk
-        if len(data) > 65536:
-            break
-    return data
-
-
-def _build_ws_frame(payload: bytes) -> bytes:
-    first = bytes([0x81])  # FIN + text frame
-    mask_bit = 0x80
-    size = len(payload)
-
-    if size < 126:
-        header = first + bytes([mask_bit | size])
-    elif size < (1 << 16):
-        header = first + bytes([mask_bit | 126]) + size.to_bytes(2, "big")
-    else:
-        header = first + bytes([mask_bit | 127]) + size.to_bytes(8, "big")
-
-    mask = secrets.token_bytes(4)
-    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return header + mask + masked
-
-
-def send_ws_json(message: dict[str, Any]) -> None:
-    body = json.dumps(message, ensure_ascii=False).encode("utf-8")
-    key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
-    expected_accept = base64.b64encode(hashlib.sha1(f"{key}{GUID}".encode("ascii")).digest()).decode("ascii")
-
-    request = (
-        f"GET {WS_PATH} HTTP/1.1\r\n"
-        f"Host: {WS_HOST}:{WS_PORT}\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        f"Sec-WebSocket-Key: {key}\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n"
-    ).encode("ascii")
-
-    with socket.create_connection((WS_HOST, WS_PORT), timeout=WS_TIMEOUT) as sock:
-        sock.settimeout(WS_TIMEOUT)
-        sock.sendall(request)
-        response = _recv_until(sock, b"\r\n\r\n").decode("latin1", errors="ignore")
-        if "101" not in response.split("\r\n", 1)[0]:
-            raise RuntimeError("websocket handshake failed")
-        if expected_accept not in response:
-            raise RuntimeError("invalid websocket accept key")
-        sock.sendall(_build_ws_frame(body))
-
-
-def fallback_log(message: dict[str, Any]) -> None:
-    path_env = os.environ.get(E.FALLBACK_LOG)
-    if path_env:
-        log_path = Path(path_env).expanduser()
-    else:
-        log_path = Path.cwd() / ".claude" / "meeting-room" / "discussion.log.jsonl"
-
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(message, ensure_ascii=False) + "\n")
-
-
 def main() -> int:
     if not is_meeting_mode_active():
         return 0
     if is_subagent_context():
         return 0
 
-    payload = parse_payload()
+    payload = parse_json_stdin()
     if not payload:
         return 0
-    hook_event = str(payload.get("hook_event_name") or "").strip().lower()
+    hook_event = as_str(payload.get("hook_event_name")).lower()
     if hook_event != "posttooluse":
         return 0
 
@@ -230,13 +119,11 @@ def main() -> int:
         return 0
 
     message = build_event_message(payload, normalized)
-    try:
-        send_ws_json(message)
-    except Exception:
-        try:
-            fallback_log(message)
-        except Exception:
-            pass
+    relay_json_with_fallback(
+        message,
+        default_log_path=default_meeting_room_path("discussion.log.jsonl"),
+        fallback_env_var=E.FALLBACK_LOG,
+    )
     return 0
 
 

--- a/src/packages/meeting-room-hooks/tests/test_hook_scripts.py
+++ b/src/packages/meeting-room-hooks/tests/test_hook_scripts.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+HOOKS_DIR = REPO_ROOT / "src" / "packages" / "meeting-room-hooks"
+
+
+def reserve_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class HookScriptTestCase(unittest.TestCase):
+    maxDiff = None
+
+    def run_hook(
+        self,
+        script_name: str,
+        payload: dict,
+        *,
+        env: dict[str, str] | None = None,
+        cwd: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        merged_env = dict(env or {})
+        return subprocess.run(
+            [sys.executable, str(HOOKS_DIR / script_name)],
+            input=json.dumps(payload, ensure_ascii=False),
+            text=True,
+            capture_output=True,
+            cwd=str(cwd or REPO_ROOT),
+            env={**dict(os_environ_subset()), **merged_env},
+            check=False,
+        )
+
+
+def os_environ_subset() -> dict[str, str]:
+    keys = ("PATH", "PYTHONPATH", "HOME", "TMPDIR", "TMP", "TEMP")
+    result: dict[str, str] = {}
+    for key in keys:
+        value = os.environ.get(key)
+        if isinstance(value, str):
+            result[key] = value
+    return result
+
+
+class HookBehaviorTests(HookScriptTestCase):
+    def create_active_file(self, root: Path) -> Path:
+        active_file = root / ".claude" / "meeting-room" / ".active"
+        active_file.parent.mkdir(parents=True, exist_ok=True)
+        active_file.write_text("", encoding="utf-8")
+        return active_file
+
+    def test_enforce_broadcast_blocks_directed_message(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+
+            result = self.run_hook(
+                "enforce-broadcast.py",
+                {"tool_input": {"type": "message", "content": "private"}},
+                env={"MEETING_ROOM_ACTIVE_FILE": str(active_file)},
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("directed", result.stderr)
+
+    def test_approval_gate_allows_open_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+            approval_file = root / "approval.json"
+            approval_file.write_text(json.dumps({"mode": "open"}), encoding="utf-8")
+
+            result = self.run_hook(
+                "approval-gate.py",
+                {},
+                env={
+                    "MEETING_ROOM_ACTIVE_FILE": str(active_file),
+                    "MEETING_ROOM_APPROVAL_FILE": str(approval_file),
+                },
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(result.stderr, "")
+
+    def test_ws_relay_falls_back_to_discussion_log(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+            fallback_log = root / "discussion.jsonl"
+
+            result = self.run_hook(
+                "ws-relay.py",
+                {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "SendMessage",
+                    "tool_input": {"type": "broadcast", "content": "hello team"},
+                    "tool_response": {"routing": {"sender": "planner", "content": "hello team"}},
+                    "metadata": {"team": "alpha", "meetingId": "meeting-1"},
+                    "agent_id": "planner@alpha",
+                },
+                env={
+                    "MEETING_ROOM_ACTIVE_FILE": str(active_file),
+                    "MEETING_ROOM_FALLBACK_LOG": str(fallback_log),
+                    "MEETING_ROOM_WS_PORT": str(reserve_tcp_port()),
+                },
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            lines = fallback_log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 1)
+            entry = json.loads(lines[0])
+            self.assertEqual(entry["sender"], "planner")
+            self.assertEqual(entry["team"], "alpha")
+            self.assertEqual(entry["meetingId"], "meeting-1")
+            self.assertEqual(entry["content"], "hello team")
+
+    def test_stop_relay_falls_back_with_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+            fallback_log = root / "stop.jsonl"
+
+            result = self.run_hook(
+                "stop-relay.py",
+                {
+                    "hook_event_name": "Stop",
+                    "assistant_message": "最終回答です",
+                },
+                env={
+                    "MEETING_ROOM_ACTIVE_FILE": str(active_file),
+                    "MEETING_ROOM_FALLBACK_LOG": str(fallback_log),
+                    "MEETING_ROOM_WS_PORT": str(reserve_tcp_port()),
+                    "CLAUDE_AGENT_NAME": "leader",
+                    "CLAUDE_TEAM_NAME": "alpha",
+                    "MEETING_ROOM_MEETING_ID": "meeting-2",
+                },
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            entry = json.loads(fallback_log.read_text(encoding="utf-8").splitlines()[0])
+            self.assertIn("[[[MEETING_ROOM_RESPONSE_START]]]", entry["content"])
+            self.assertIn("最終回答です", entry["content"])
+            self.assertEqual(entry["meetingId"], "meeting-2")
+
+    def test_subagent_status_relay_uses_status_log_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+            status_log = root / "status.jsonl"
+
+            result = self.run_hook(
+                "subagent-status-relay.py",
+                {"hook_event_name": "PostToolUse"},
+                env={
+                    "MEETING_ROOM_ACTIVE_FILE": str(active_file),
+                    "MEETING_ROOM_STATUS_LOG": str(status_log),
+                    "MEETING_ROOM_WS_PORT": str(reserve_tcp_port()),
+                    "CLAUDE_SUBAGENT_NAME": "implementer",
+                    "CLAUDE_TEAM_NAME": "alpha",
+                },
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            entry = json.loads(status_log.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(entry["sender"], "implementer")
+            self.assertEqual(entry["status"], "completed")
+
+    def test_team_event_relay_falls_back_for_task(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active_file = self.create_active_file(root)
+            fallback_log = root / "team-event.jsonl"
+
+            result = self.run_hook(
+                "team-event-relay.py",
+                {
+                    "hook_event_name": "PostToolUse",
+                    "tool_name": "Task",
+                    "tool_input": {"description": "Investigate duplicated hook utilities"},
+                },
+                env={
+                    "MEETING_ROOM_ACTIVE_FILE": str(active_file),
+                    "MEETING_ROOM_FALLBACK_LOG": str(fallback_log),
+                    "MEETING_ROOM_WS_PORT": str(reserve_tcp_port()),
+                    "CLAUDE_TEAM_NAME": "alpha",
+                },
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            entry = json.loads(fallback_log.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(entry["sender"], "system")
+            self.assertEqual(entry["rawType"], "task")
+            self.assertIn("Task を作成", entry["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/packages/meeting-room-hooks/tests/test_hook_units.py
+++ b/src/packages/meeting-room-hooks/tests/test_hook_units.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+HOOKS_DIR = Path(__file__).resolve().parents[1]
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+import hook_common
+import hook_text
+import hook_transport
+from contracts import ApprovalGateFields as AG
+from contracts import HookEnvVars as E
+from contracts import RelayPayloadFields as F
+from contracts import ResponseMarkers as M
+
+
+def load_hook_module(module_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(module_name, HOOKS_DIR / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+approval_gate = load_hook_module("approval_gate", "approval-gate.py")
+enforce_broadcast = load_hook_module("enforce_broadcast", "enforce-broadcast.py")
+stop_relay = load_hook_module("stop_relay", "stop-relay.py")
+team_event_relay = load_hook_module("team_event_relay", "team-event-relay.py")
+ws_relay = load_hook_module("ws_relay", "ws-relay.py")
+
+
+class HookCommonTests(unittest.TestCase):
+    def test_as_str_and_get_env_str_trim_values(self) -> None:
+        self.assertEqual(hook_common.as_str("  value  "), "value")
+        self.assertEqual(hook_common.as_str(123), "")
+        self.assertEqual(
+            hook_common.get_env_str("MEETING_ROOM_TEST", env={"MEETING_ROOM_TEST": "  present  "}),
+            "present",
+        )
+
+    def test_default_meeting_room_path_uses_cwd(self) -> None:
+        path = hook_common.default_meeting_room_path("logs", "hook.jsonl", cwd=Path("/tmp/work"))
+        self.assertEqual(path, Path("/tmp/work/.claude/meeting-room/logs/hook.jsonl"))
+
+    def test_candidate_active_paths_include_env_and_default_locations(self) -> None:
+        paths = hook_common.candidate_active_paths(
+            env={E.ACTIVE_FILE: "/tmp/custom.active"},
+            cwd=Path("/tmp/project"),
+            home=Path("/tmp/home"),
+        )
+        self.assertEqual(
+            paths,
+            [
+                Path("/tmp/custom.active"),
+                Path("/tmp/project/.claude/meeting-room/.active"),
+                Path("/tmp/home/.claude/meeting-room/.active"),
+            ],
+        )
+
+    def test_is_meeting_mode_active_checks_any_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            active = root / ".claude" / "meeting-room" / ".active"
+            active.parent.mkdir(parents=True, exist_ok=True)
+            active.write_text("", encoding="utf-8")
+
+            self.assertTrue(
+                hook_common.is_meeting_mode_active(
+                    env={},
+                    cwd=root,
+                    home=Path("/tmp/unused-home"),
+                )
+            )
+
+    def test_is_subagent_context_uses_env(self) -> None:
+        self.assertTrue(hook_common.is_subagent_context(env={"CLAUDE_SUBAGENT_NAME": "researcher"}))
+        self.assertFalse(hook_common.is_subagent_context(env={}))
+
+    def test_parse_json_stdin_returns_only_dict_payloads(self) -> None:
+        self.assertEqual(hook_common.parse_json_stdin(io.StringIO('{"ok": true}')), {"ok": True})
+        self.assertEqual(hook_common.parse_json_stdin(io.StringIO('["list"]')), {})
+        self.assertEqual(hook_common.parse_json_stdin(io.StringIO("{not-json")), {})
+
+    def test_extract_mapping_returns_dict_only(self) -> None:
+        payload = {"meta": {"value": 1}, "content": "hello"}
+        self.assertEqual(hook_common.extract_mapping(payload, "meta"), {"value": 1})
+        self.assertEqual(hook_common.extract_mapping(payload, "content"), {})
+
+    def test_resolve_repo_root_prefers_settings_then_hooks_then_project(self) -> None:
+        settings_env = {E.SETTINGS_FILE: "/repo/.claude/settings.json"}
+        self.assertEqual(hook_common.resolve_repo_root(env=settings_env), Path("/repo"))
+
+        hooks_env = {E.HOOKS_DIR: "/repo/src/packages/meeting-room-hooks"}
+        self.assertEqual(hook_common.resolve_repo_root(env=hooks_env), Path("/repo/src/packages"))
+
+        project_env = {"CLAUDE_PROJECT_DIR": "/repo/project"}
+        self.assertEqual(hook_common.resolve_repo_root(env=project_env), Path("/repo/project"))
+
+    def test_resolve_repo_root_falls_back_to_cwd(self) -> None:
+        self.assertEqual(hook_common.resolve_repo_root(env={}, cwd=Path("/tmp/project")), Path("/tmp/project"))
+
+    def test_resolve_approval_file_prefers_direct_path(self) -> None:
+        path = hook_common.resolve_approval_file(env={E.APPROVAL_FILE: "/tmp/approval.json"})
+        self.assertEqual(path, Path("/tmp/approval.json"))
+
+    def test_resolve_approval_file_returns_none_without_meeting_id(self) -> None:
+        self.assertIsNone(hook_common.resolve_approval_file(env={}))
+
+    def test_resolve_approval_file_uses_custom_dir_or_repo_root(self) -> None:
+        custom_dir_path = hook_common.resolve_approval_file(
+            env={E.MEETING_ID: "meeting-1", E.APPROVAL_DIR: "/tmp/approval"},
+        )
+        self.assertEqual(custom_dir_path, Path("/tmp/approval/meeting-1.json"))
+
+        repo_root_path = hook_common.resolve_approval_file(
+            env={E.MEETING_ID: "meeting-2"},
+            repo_root=Path("/repo"),
+        )
+        self.assertEqual(repo_root_path, Path("/repo/.claude/meeting-room/approval/meeting-2.json"))
+
+
+class HookTextTests(unittest.TestCase):
+    def test_path_only_reference_detection(self) -> None:
+        self.assertTrue(hook_text.is_path_only_reference("/Users/test/debug.jsonl"))
+        self.assertFalse(hook_text.is_path_only_reference("debug.jsonl is available"))
+
+    def test_single_line_prompt_detection(self) -> None:
+        self.assertTrue(hook_text.is_single_line_prompt("@agent ❯ continue"))
+        self.assertFalse(hook_text.is_single_line_prompt("@agent\n❯ continue"))
+
+    def test_valid_message_content_filters_internal_noise(self) -> None:
+        self.assertFalse(hook_text.is_valid_message_content(""))
+        self.assertFalse(hook_text.is_valid_message_content(f"{M.START}\nbody"))
+        self.assertFalse(hook_text.is_valid_message_content("@agent ❯ continue"))
+        self.assertFalse(hook_text.is_valid_message_content("/Users/test/debug.json"))
+        self.assertTrue(hook_text.is_valid_message_content("hello team"))
+
+    def test_valid_assistant_text_filters_prompts_and_paths(self) -> None:
+        self.assertFalse(hook_text.is_valid_assistant_text("@agent ❯ continue"))
+        self.assertFalse(hook_text.is_valid_assistant_text("/Users/test/debug.json"))
+        self.assertTrue(hook_text.is_valid_assistant_text("final answer"))
+
+
+class HookTransportTests(unittest.TestCase):
+    def test_load_ws_config_uses_defaults_and_handles_invalid_values(self) -> None:
+        default_config = hook_transport._load_ws_config(env={})
+        self.assertEqual(default_config.host, "127.0.0.1")
+        self.assertEqual(default_config.port, 9999)
+        self.assertEqual(default_config.path, "/")
+        self.assertEqual(default_config.timeout, 0.8)
+
+        invalid_config = hook_transport._load_ws_config(
+            env={E.WS_PORT: "not-a-port", E.WS_TIMEOUT: "oops", E.WS_HOST: "localhost", E.WS_PATH: "/relay"}
+        )
+        self.assertEqual(invalid_config.host, "localhost")
+        self.assertEqual(invalid_config.port, 9999)
+        self.assertEqual(invalid_config.path, "/relay")
+        self.assertEqual(invalid_config.timeout, 0.8)
+
+    def test_append_jsonl_and_resolve_log_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            log_path = root / "logs" / "events.jsonl"
+            hook_transport.append_jsonl(log_path, {"ok": True})
+            self.assertEqual(json.loads(log_path.read_text(encoding="utf-8").splitlines()[0]), {"ok": True})
+
+            resolved = hook_transport.resolve_log_path(
+                log_path,
+                env_var=E.FALLBACK_LOG,
+                env={E.FALLBACK_LOG: str(root / "custom.jsonl")},
+            )
+            self.assertEqual(resolved, root / "custom.jsonl")
+
+    def test_relay_json_with_fallback_appends_when_ws_send_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fallback_path = root / "fallback.jsonl"
+
+            with mock.patch.object(hook_transport, "send_ws_json", side_effect=RuntimeError("down")):
+                hook_transport.relay_json_with_fallback(
+                    {"content": "hello"},
+                    default_log_path=root / "default.jsonl",
+                    fallback_env_var=E.FALLBACK_LOG,
+                    env={E.FALLBACK_LOG: str(fallback_path)},
+                )
+
+            entry = json.loads(fallback_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(entry["content"], "hello")
+
+
+class ApprovalGateTests(unittest.TestCase):
+    def test_parse_approval_state_and_bypass_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "approval.json"
+            path.write_text(json.dumps({AG.MODE: "open"}), encoding="utf-8")
+            self.assertEqual(approval_gate.parse_approval_state(path), {AG.MODE: "open"})
+
+            invalid_path = Path(temp_dir) / "invalid.json"
+            invalid_path.write_text("{oops", encoding="utf-8")
+            self.assertIsNone(approval_gate.parse_approval_state(invalid_path))
+
+        self.assertTrue(approval_gate.is_bypass_mode_enabled(True))
+        self.assertTrue(approval_gate.is_bypass_mode_enabled(" yes "))
+        self.assertFalse(approval_gate.is_bypass_mode_enabled("no"))
+
+
+class EnforceBroadcastTests(unittest.TestCase):
+    def test_extract_send_message_type_prefers_tool_input(self) -> None:
+        self.assertEqual(
+            enforce_broadcast.extract_send_message_type({"tool_input": {"type": "broadcast"}, "type": "message"}),
+            "broadcast",
+        )
+        self.assertEqual(enforce_broadcast.extract_send_message_type({"type": "message"}), "message")
+        self.assertIsNone(enforce_broadcast.extract_send_message_type({}))
+
+
+class TeamEventRelayTests(unittest.TestCase):
+    def test_should_emit_detects_supported_tool_names(self) -> None:
+        self.assertEqual(team_event_relay.should_emit({"tool_name": "Task"}), (True, "task"))
+        self.assertEqual(
+            team_event_relay.should_emit({"metadata": {"tool_name": "create-team"}}),
+            (True, "create-team"),
+        )
+        self.assertEqual(team_event_relay.should_emit({"tool_name": "ReadFile"}), (False, "readfile"))
+
+    def test_build_event_message_formats_team_create_and_task(self) -> None:
+        with mock.patch.object(team_event_relay, "get_env_str", side_effect=lambda name: {"CLAUDE_TEAM_NAME": "alpha", E.MEETING_ID: "meeting-1"}.get(name, "")):
+            team_message = team_event_relay.build_event_message({"tool_input": {"members": ["a", "b"]}}, "teamcreate")
+            task_message = team_event_relay.build_event_message(
+                {"tool_input": {"description": "Investigate a very long task " * 20}},
+                "task",
+            )
+
+        self.assertEqual(team_message[F.SENDER], "system")
+        self.assertIn("メンバー数: 2", team_message[F.CONTENT])
+        self.assertEqual(team_message[F.MEETING_ID], "meeting-1")
+        self.assertIn("Task を作成", task_message[F.CONTENT])
+        self.assertTrue(task_message[F.CONTENT].endswith("..."))
+
+
+class WsRelayTests(unittest.TestCase):
+    def test_sender_from_agent_id(self) -> None:
+        self.assertEqual(ws_relay._sender_from_agent_id("planner@alpha"), "planner")
+        self.assertEqual(ws_relay._sender_from_agent_id("leader"), "leader")
+
+    def test_resolve_message_prefers_routing_sender_and_content(self) -> None:
+        payload = {
+            "tool_input": {"type": "broadcast", "content": "fallback content"},
+            "tool_response": {"routing": {"sender": "planner", "content": "hello team"}},
+            "metadata": {"team": "alpha", F.MEETING_ID: "meeting-1"},
+            "agent_id": "planner@alpha",
+        }
+        with mock.patch.object(ws_relay, "get_env_str", return_value=""):
+            resolved = ws_relay._resolve_message(payload)
+
+        self.assertEqual(resolved.sender, "planner")
+        self.assertEqual(resolved.subagent, "planner")
+        self.assertEqual(resolved.content, "hello team")
+        self.assertEqual(resolved.team, "alpha")
+        self.assertEqual(resolved.meeting_id, "meeting-1")
+        self.assertEqual(resolved.raw_type, "broadcast")
+        self.assertEqual(resolved.sender_source, "routing")
+
+    def test_resolve_message_falls_back_to_env_or_leader(self) -> None:
+        payload = {
+            "tool_input": {"content": "/Users/test/debug.jsonl"},
+            "metadata": {},
+            "agent_id": "",
+        }
+
+        def env_lookup(name: str) -> str:
+            return {"CLAUDE_SUBAGENT_NAME": "reviewer", "CLAUDE_TEAM_NAME": "beta"}.get(name, "")
+
+        with mock.patch.object(ws_relay, "get_env_str", side_effect=env_lookup):
+            resolved = ws_relay._resolve_message(payload)
+        self.assertEqual(resolved.sender, "reviewer")
+        self.assertEqual(resolved.sender_source, "env_subagent")
+        self.assertEqual(resolved.content, "")
+        self.assertEqual(resolved.team, "beta")
+
+        with mock.patch.object(ws_relay, "get_env_str", return_value=""):
+            fallback = ws_relay._resolve_message({"tool_input": {}, "tool_response": {}, "metadata": {}, "agent_id": ""})
+        self.assertEqual(fallback.sender, "leader")
+        self.assertEqual(fallback.sender_source, "fallback")
+
+    def test_build_message_and_write_debug(self) -> None:
+        resolved = ws_relay.ResolvedMessage(
+            sender="planner",
+            subagent="planner",
+            content="hello team",
+            team="alpha",
+            meeting_id="meeting-1",
+            raw_type="broadcast",
+            sender_source="routing",
+        )
+        message = ws_relay.build_message(resolved)
+        self.assertEqual(message[F.SENDER], "planner")
+        self.assertEqual(message[F.CONTENT], "hello team")
+        self.assertEqual(message[F.MEETING_ID], "meeting-1")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            debug_path = Path(temp_dir) / "ws-debug.jsonl"
+            with mock.patch.object(ws_relay, "get_env_str", side_effect=lambda name: str(debug_path) if name == E.WS_DEBUG_LOG else ""):
+                ws_relay.write_debug({"tool_input": {}, "tool_response": {}, "metadata": {}}, resolved)
+            entry = json.loads(debug_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(entry["resolvedSender"], "planner")
+            self.assertEqual(entry[F.MEETING_ID], "meeting-1")
+
+
+class StopRelayTests(unittest.TestCase):
+    def test_extract_text_blocks_and_pick_best_text(self) -> None:
+        blocks = stop_relay._extract_text_blocks(
+            [
+                {"type": "text", "text": "first"},
+                {"content": [{"type": "text", "text": "second"}]},
+                "third",
+            ]
+        )
+        self.assertEqual(blocks, ["first", "first", "second", "second", "third"])
+        self.assertEqual(stop_relay._pick_best_text(["x", "longer text", "x"]), "longer text")
+
+    def test_extract_assistant_text_from_record(self) -> None:
+        record = {"role": "assistant", "message": [{"type": "text", "text": "final answer"}]}
+        self.assertEqual(stop_relay._extract_assistant_text_from_record(record), "final answer")
+        self.assertEqual(stop_relay._extract_assistant_text_from_record({"role": "user"}), "")
+
+    def test_extract_assistant_from_transcript_reads_latest_assistant_message(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transcript = Path(temp_dir) / "transcript.jsonl"
+            transcript.write_text(
+                "\n".join(
+                    [
+                        json.dumps({"role": "user", "message": "hello"}, ensure_ascii=False),
+                        json.dumps({"role": "assistant", "message": [{"type": "text", "text": "latest answer"}]}, ensure_ascii=False),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                stop_relay._extract_assistant_from_transcript({"transcript_path": str(transcript)}),
+                "latest answer",
+            )
+
+    def test_extract_assistant_response_prefers_env_then_direct_then_transcript(self) -> None:
+        with mock.patch.object(stop_relay, "get_env_str", side_effect=lambda name: {"CLAUDE_RESPONSE": "env answer"}.get(name, "")):
+            self.assertEqual(stop_relay.extract_assistant_response({}), "env answer")
+
+        with mock.patch.object(stop_relay, "get_env_str", return_value=""):
+            direct = stop_relay.extract_assistant_response({"assistant_message": "direct answer"})
+        self.assertEqual(direct, "direct answer")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            transcript = Path(temp_dir) / "transcript.jsonl"
+            transcript.write_text(
+                json.dumps({"role": "assistant", "message": [{"type": "text", "text": "transcript answer"}]}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            with mock.patch.object(stop_relay, "get_env_str", return_value=""):
+                transcript_value = stop_relay.extract_assistant_response({"transcript_path": str(transcript)})
+            self.assertEqual(transcript_value, "transcript answer")
+
+    def test_build_message_and_write_debug(self) -> None:
+        def env_lookup(name: str) -> str:
+            return {
+                "CLAUDE_AGENT_NAME": "leader",
+                "CLAUDE_TEAM_NAME": "alpha",
+                E.MEETING_ID: "meeting-2",
+            }.get(name, "")
+
+        with mock.patch.object(stop_relay, "get_env_str", side_effect=env_lookup):
+            message = stop_relay.build_message("final answer")
+        self.assertEqual(message[F.SENDER], "leader")
+        self.assertIn(M.START, message[F.CONTENT])
+        self.assertEqual(message[F.MEETING_ID], "meeting-2")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            debug_path = Path(temp_dir) / "stop-debug.jsonl"
+
+            def debug_env_lookup(name: str) -> str:
+                return str(debug_path) if name == E.STOP_DEBUG_LOG else ""
+
+            with mock.patch.object(stop_relay, "get_env_str", side_effect=debug_env_lookup):
+                stop_relay.write_debug({"assistant_message": "hello"}, "hello")
+            entry = json.loads(debug_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertTrue(entry["hasContent"])
+            self.assertEqual(entry["contentPreview"], "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/packages/meeting-room-hooks/ws-relay.py
+++ b/src/packages/meeting-room-hooks/ws-relay.py
@@ -7,14 +7,7 @@ Falls back to local JSONL logging when relay is unavailable.
 
 from __future__ import annotations
 
-import base64
-import hashlib
 import json
-import os
-import re
-import secrets
-import socket
-import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,14 +18,18 @@ from contracts import (
     HookEnvVars as E,
     RelayPayloadFields as F,
     RelayPayloadTypes as T,
-    ResponseMarkers as M,
 )
+from hook_common import (
+    as_str,
+    default_meeting_room_path,
+    extract_mapping,
+    get_env_str,
+    is_meeting_mode_active,
+    parse_json_stdin,
+)
+from hook_text import is_valid_message_content
+from hook_transport import relay_json_with_fallback
 
-GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-WS_HOST = os.environ.get(E.WS_HOST, "127.0.0.1")
-WS_PORT = int(os.environ.get(E.WS_PORT, "9999"))
-WS_PATH = os.environ.get(E.WS_PATH, "/")
-WS_TIMEOUT = float(os.environ.get(E.WS_TIMEOUT, "0.8"))
 DEFAULT_DEBUG_LOG = Path.cwd() / ".claude" / "meeting-room" / "ws-hook.log.jsonl"
 
 
@@ -88,64 +85,6 @@ class ResolvedMessage:
     sender_source: str
 
 
-PATH_ONLY_PATTERN = r"^(?:/Users/|/home/|[A-Za-z]:\\).+\.(?:jsonl|json|md|txt|log)$"
-
-
-def _candidate_active_paths() -> list[Path]:
-    env_path = os.environ.get(E.ACTIVE_FILE)
-    paths: list[Path] = []
-    if env_path:
-        paths.append(Path(env_path).expanduser())
-    cwd = Path.cwd()
-    paths.append(cwd / ".claude" / "meeting-room" / ".active")
-    paths.append(Path.home() / ".claude" / "meeting-room" / ".active")
-    return paths
-
-
-def is_meeting_mode_active() -> bool:
-    for path in _candidate_active_paths():
-        if path.exists():
-            return True
-    return False
-
-
-def parse_payload() -> SendMessageHookPayload:
-    raw = sys.stdin.read().strip()
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if isinstance(data, dict):
-        return data
-    return {}
-
-
-def _extract_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
-    value = payload.get(key)
-    if isinstance(value, dict):
-        return value
-    return {}
-
-
-def _as_str(value: Any) -> str:
-    return value.strip() if isinstance(value, str) else ""
-
-
-def _is_valid_message_content(value: str) -> bool:
-    if not value.strip():
-        return False
-    compact = value.strip()
-    if compact.startswith(M.START):
-        return False
-    if compact.startswith("@") and "❯" in compact and "\n" not in compact:
-        return False
-    if re.match(PATH_ONLY_PATTERN, compact):
-        return False
-    return True
-
-
 def _sender_from_agent_id(agent_id: str) -> str:
     if "@" in agent_id:
         return agent_id.split("@", 1)[0].strip()
@@ -153,17 +92,17 @@ def _sender_from_agent_id(agent_id: str) -> str:
 
 
 def _resolve_message(payload: SendMessageHookPayload) -> ResolvedMessage:
-    tool_input = _extract_mapping(payload, "tool_input")
-    response = _extract_mapping(payload, "tool_response")
-    routing = _extract_mapping(response, "routing")
-    metadata = _extract_mapping(payload, "metadata")
+    tool_input = extract_mapping(payload, "tool_input")
+    response = extract_mapping(payload, "tool_response")
+    routing = extract_mapping(response, "routing")
+    metadata = extract_mapping(payload, "metadata")
 
-    routing_sender = _as_str(routing.get("sender"))
-    env_subagent = _as_str(os.environ.get("CLAUDE_SUBAGENT_NAME"))
-    env_agent = _as_str(os.environ.get("CLAUDE_AGENT_NAME"))
-    metadata_subagent = _as_str(metadata.get("subagent"))
-    metadata_agent = _as_str(metadata.get("agent"))
-    agent_id_sender = _sender_from_agent_id(_as_str(payload.get("agent_id")))
+    routing_sender = as_str(routing.get("sender"))
+    env_subagent = get_env_str("CLAUDE_SUBAGENT_NAME")
+    env_agent = get_env_str("CLAUDE_AGENT_NAME")
+    metadata_subagent = as_str(metadata.get("subagent"))
+    metadata_agent = as_str(metadata.get("agent"))
+    agent_id_sender = _sender_from_agent_id(as_str(payload.get("agent_id")))
 
     subagent = routing_sender or env_subagent or metadata_subagent or agent_id_sender or None
     sender = routing_sender
@@ -190,14 +129,19 @@ def _resolve_message(payload: SendMessageHookPayload) -> ResolvedMessage:
             sender_source = "fallback"
 
     content_candidates = [
-        _as_str(routing.get("content")),
-        _as_str(response.get("content")),
-        _as_str(tool_input.get("content")),
+        as_str(routing.get("content")),
+        as_str(response.get("content")),
+        as_str(tool_input.get("content")),
     ]
-    content = next((candidate for candidate in content_candidates if _is_valid_message_content(candidate)), "")
-    team = _as_str(metadata.get("team")) or _as_str(os.environ.get("CLAUDE_TEAM_NAME")) or "unknown"
-    meeting_id = _as_str(metadata.get("meeting_id")) or _as_str(os.environ.get(E.MEETING_ID)) or None
-    raw_type = _as_str(tool_input.get("type")) or "message"
+    content = next((candidate for candidate in content_candidates if is_valid_message_content(candidate)), "")
+    team = as_str(metadata.get("team")) or get_env_str("CLAUDE_TEAM_NAME") or "unknown"
+    meeting_id = (
+        as_str(metadata.get(F.MEETING_ID))
+        or as_str(metadata.get("meeting_id"))
+        or get_env_str(E.MEETING_ID)
+        or None
+    )
+    raw_type = as_str(tool_input.get("type")) or "message"
 
     return ResolvedMessage(
         sender=sender,
@@ -211,17 +155,17 @@ def _resolve_message(payload: SendMessageHookPayload) -> ResolvedMessage:
 
 
 def write_debug(payload: SendMessageHookPayload, resolved: ResolvedMessage) -> None:
-    path = os.environ.get(E.WS_DEBUG_LOG, "").strip()
+    path = get_env_str(E.WS_DEBUG_LOG)
     debug_path = Path(path).expanduser() if path else DEFAULT_DEBUG_LOG
     debug_path.parent.mkdir(parents=True, exist_ok=True)
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "payloadKeys": sorted(payload.keys()),
-        "toolInputKeys": sorted(_extract_mapping(payload, "tool_input").keys()),
-        "toolResponseKeys": sorted(_extract_mapping(payload, "tool_response").keys()),
-        "routingKeys": sorted(_extract_mapping(_extract_mapping(payload, "tool_response"), "routing").keys()),
-        "envSubagent": _as_str(os.environ.get("CLAUDE_SUBAGENT_NAME")),
-        "envAgent": _as_str(os.environ.get("CLAUDE_AGENT_NAME")),
+        "toolInputKeys": sorted(extract_mapping(payload, "tool_input").keys()),
+        "toolResponseKeys": sorted(extract_mapping(payload, "tool_response").keys()),
+        "routingKeys": sorted(extract_mapping(extract_mapping(payload, "tool_response"), "routing").keys()),
+        "envSubagent": get_env_str("CLAUDE_SUBAGENT_NAME"),
+        "envAgent": get_env_str("CLAUDE_AGENT_NAME"),
         "resolvedSender": resolved.sender,
         "resolvedSubagent": resolved.subagent,
         "senderSource": resolved.sender_source,
@@ -250,83 +194,16 @@ def build_message(resolved: ResolvedMessage) -> dict[str, Any]:
     }
 
 
-def _recv_until(sock: socket.socket, marker: bytes) -> bytes:
-    data = b""
-    while marker not in data:
-        chunk = sock.recv(4096)
-        if not chunk:
-            break
-        data += chunk
-        if len(data) > 65536:
-            break
-    return data
-
-
-def _build_ws_frame(payload: bytes) -> bytes:
-    # Client frames must be masked.
-    first = bytes([0x81])  # FIN + text frame
-    mask_bit = 0x80
-    size = len(payload)
-
-    if size < 126:
-        header = first + bytes([mask_bit | size])
-    elif size < (1 << 16):
-        header = first + bytes([mask_bit | 126]) + size.to_bytes(2, "big")
-    else:
-        header = first + bytes([mask_bit | 127]) + size.to_bytes(8, "big")
-
-    mask = secrets.token_bytes(4)
-    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return header + mask + masked
-
-
-def send_ws_json(message: dict[str, Any]) -> None:
-    body = json.dumps(message, ensure_ascii=False).encode("utf-8")
-    key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
-    expected_accept = base64.b64encode(hashlib.sha1(f"{key}{GUID}".encode("ascii")).digest()).decode("ascii")
-
-    request = (
-        f"GET {WS_PATH} HTTP/1.1\r\n"
-        f"Host: {WS_HOST}:{WS_PORT}\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        f"Sec-WebSocket-Key: {key}\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n"
-    ).encode("ascii")
-
-    with socket.create_connection((WS_HOST, WS_PORT), timeout=WS_TIMEOUT) as sock:
-        sock.settimeout(WS_TIMEOUT)
-        sock.sendall(request)
-        response = _recv_until(sock, b"\r\n\r\n").decode("latin1", errors="ignore")
-        if "101" not in response.split("\r\n", 1)[0]:
-            raise RuntimeError("websocket handshake failed")
-        if expected_accept not in response:
-            raise RuntimeError("invalid websocket accept key")
-        sock.sendall(_build_ws_frame(body))
-
-
-def fallback_log(message: dict[str, Any]) -> None:
-    path_env = os.environ.get(E.FALLBACK_LOG)
-    if path_env:
-        log_path = Path(path_env).expanduser()
-    else:
-        log_path = Path.cwd() / ".claude" / "meeting-room" / "discussion.log.jsonl"
-
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(message, ensure_ascii=False) + "\n")
-
-
 def main() -> int:
     if not is_meeting_mode_active():
         return 0
 
-    payload = parse_payload()
+    payload = parse_json_stdin()
     if not payload:
         return 0
-    if _as_str(payload.get("hook_event_name")).lower() != "posttooluse":
+    if as_str(payload.get("hook_event_name")).lower() != "posttooluse":
         return 0
-    if _as_str(payload.get("tool_name")).lower() != "sendmessage":
+    if as_str(payload.get("tool_name")).lower() != "sendmessage":
         return 0
 
     resolved = _resolve_message(payload)
@@ -334,17 +211,15 @@ def main() -> int:
         write_debug(payload, resolved)
     except Exception:
         pass
-    if not _is_valid_message_content(resolved.content):
+    if not is_valid_message_content(resolved.content):
         return 0
 
     message = build_message(resolved)
-    try:
-        send_ws_json(message)
-    except Exception:
-        try:
-            fallback_log(message)
-        except Exception:
-            pass
+    relay_json_with_fallback(
+        message,
+        default_log_path=default_meeting_room_path("discussion.log.jsonl"),
+        fallback_env_var=E.FALLBACK_LOG,
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- extract shared Meeting Room hook helpers for context, transport, and text filtering
- slim down each Python hook so script files keep payload-specific logic only
- add script-level and unit-level tests for hook behavior and relay resolution paths

## Verification
- python3 -m unittest discover -s src/packages/meeting-room-hooks/tests
- node scripts/check-hook-literals.mjs
- node scripts/generate-hook-contracts.mjs --check
- npm --prefix src/apps/desktop run verify:final
- npm --prefix src/apps/desktop run e2e:web

Closes #5